### PR TITLE
Switch to windows-2019 instead of windows-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
`node-gyp` fails on `windows-2022`. Reports indicate that `windows-2019` should work as before.

Related:
 - https://github.com/prebuild/prebuild/issues/286